### PR TITLE
Fix world UUID validator

### DIFF
--- a/option.html
+++ b/option.html
@@ -20,7 +20,7 @@
   <p>
     <label>
       ワールドID(必須):<br>
-      <input type="text" name="worldID" placeholder="wrld_eb7a5096-9c93-41db-a9d7-7b349a5d4815" pattern="wr?ld_[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}" required>
+      <input type="text" name="worldID" placeholder="wrld_eb7a5096-9c93-41db-a9d7-7b349a5d4815" pattern="wr?ld_[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}" required>
     </label>
   </p>
 


### PR DESCRIPTION
VRChat allows UUID v4 violations. It is very interesting.

Counterexample:
https://vrchat.com/home/launch?worldId=wrld_30000000-0000-0000-0000-000000000000